### PR TITLE
Without Password Authentication form Ansbile to Server Macine

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,11 @@ Install Ansible in one EC2 instances
 # For Password less authentication
 In the Ansible server
 >>>ssh-keygen
-
+After This command there is public and private key is generated.
+>>>id_rsa (private key)  id_rsa_pub (Public key)
+After That copy public key from id_rsa_pub
+Go into the target server and type again
+>>>ssh-keygen
+past the public copy content into the authorized_key file section of server.
+The go into the ansible server type #ssh private key of server
+You will be able to login the server without password.


### PR DESCRIPTION
# Ansible
Ansible Project on AWS
Install Ansible in one EC2 instances
# For Password less authentication
In the Ansible server
>>>ssh-keygen
After This command there is public and private key is generated.
>>>id_rsa (private key)  id_rsa_pub (Public key)
After That copy public key from id_rsa_pub
Go into the target server and type again
>>>ssh-keygen
past the public copy content into the authorized_key file section of server.
The go into the ansible server type #ssh private key of server
You will be able to login the server without password.